### PR TITLE
feat: useDropdon 공동 컴포넌트 구현

### DIFF
--- a/src/assets/icon/toggle.svg
+++ b/src/assets/icon/toggle.svg
@@ -1,0 +1,3 @@
+<svg width="13" height="13" viewBox="0 0 13 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6.30383 11L11.5 2H1.10768L6.30383 11Z" fill="#B3B3B3"/>
+</svg>

--- a/src/component/common/Dropdown/Dropdown.jsx
+++ b/src/component/common/Dropdown/Dropdown.jsx
@@ -1,0 +1,28 @@
+import { useTheme } from 'styled-components';
+import S from './Dropdown.style';
+import toggleIcon from '@assets/icon/toggle.svg';
+
+const Dropdown = ({ isOpen, items, toggle, selectedItem, clickItem }) => {
+  const theme = useTheme();
+  return (
+    <S.DropdownWrapper>
+      <S.DropdownToggle onClick={toggle}>
+        <p style={{ fontSize: 16, color: theme.colors.grey4 }}>
+          {selectedItem}
+        </p>
+        <img src={toggleIcon} alt="토글아이콘" width={10} height={10} />
+      </S.DropdownToggle>
+      {isOpen && (
+        <S.DropdownItems>
+          {items.map((item) => (
+            <S.DropdownItem onClick={() => clickItem(item)}>
+              {item}
+            </S.DropdownItem>
+          ))}
+        </S.DropdownItems>
+      )}
+    </S.DropdownWrapper>
+  );
+};
+
+export default Dropdown;

--- a/src/component/common/Dropdown/Dropdown.style.js
+++ b/src/component/common/Dropdown/Dropdown.style.js
@@ -1,0 +1,49 @@
+import styled from 'styled-components';
+const S = {
+  DropdownWrapper: styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+
+    position: relative;
+    justify-content: center;
+    cursor: pointer;
+  `,
+  DropdownToggle: styled.div`
+    display: flex;
+    flex-direction: row;
+    gap: 8px;
+    align-items: center;
+
+    padding: 8px;
+    border: 1.5px solid ${(props) => props.theme.colors.grey2};
+    border-radius: 4px;
+  `,
+  DropdownItems: styled.ul`
+    position: absolute;
+    top: 50px;
+
+    padding: 8px;
+    border: 1.5px solid ${(props) => props.theme.colors.grey2};
+    border-radius: 4px;
+    left: 50%;
+    transform: translateX(-50%);
+
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    width: fit-content;
+    gap: 10px;
+  `,
+  DropdownItem: styled.li`
+    padding: 8px;
+    border-radius: 2px;
+    text-align: center;
+    white-space: nowrap;
+    &:hover {
+      background: ${(props) => props.theme.colors.grey2};
+    }
+  `,
+};
+
+export default S;

--- a/src/hook/UI/useCheckBox.jsx
+++ b/src/hook/UI/useCheckBox.jsx
@@ -10,8 +10,8 @@ const useCheckBox = () => {
 
   const render = () => (
     <S.CheckBoxWrapper>
-      <S.HiddenCheckBox type="checkbox" check={isCheck} onClick={toggle} />
-      <S.CustomCheckBox check={isCheck} onClick={toggle}>
+      <S.HiddenCheckBox type="checkbox" checked={isCheck} onClick={toggle} />
+      <S.CustomCheckBox checked={isCheck} onClick={toggle}>
         {isCheck ? (
           <img src={checkWhite} alt="check" width={16} height={16} />
         ) : (
@@ -28,8 +28,8 @@ const S = {
   CheckBoxWrapper: styled.div``,
   HiddenCheckBox: styled.input.attrs((props) => ({
     type: 'checkbox',
-    check: props.checisCheck,
-    onclick: props.onClick,
+    checked: props.checisCheck,
+    onClick: props.onClick,
   }))`
     display: none;
     background-color: black;

--- a/src/hook/UI/useDropdown.jsx
+++ b/src/hook/UI/useDropdown.jsx
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+import Dropdown from '../../component/common/Dropdown/Dropdown';
+
+const useDropdown = ({ title, items }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedItem, setSelectedItem] = useState(title);
+
+  const toggle = () => setIsOpen((prev) => !prev);
+
+  const clickItem = (item) => {
+    setSelectedItem(item);
+    toggle();
+  };
+
+  const render = () => {
+    return (
+      <Dropdown
+        isOpen={isOpen}
+        items={items}
+        toggle={toggle}
+        selectedItem={selectedItem}
+        clickItem={clickItem}
+      />
+    );
+  };
+
+  return { selectedItem, toggle, render };
+};
+export default useDropdown;


### PR DESCRIPTION
- useDropdown 공동 컴포넌트를 구현했습니다.
- Dropdown 내부 아이템과 default title을 props로 넘겨 사용할 수 있습니다.
- Dropdown UI 컴포넌트는 `component/common`에서 관리합니다.