### PR TITLE
Feature/login: 로그인 페이지 구현 

### DIFF
--- a/src/component/common/Button/Button.jsx
+++ b/src/component/common/Button/Button.jsx
@@ -1,0 +1,11 @@
+import S from './Button.style';
+
+const Button = ({ children, disabled = false, ...props }) => {
+  return (
+    <S.button {...props} disabled={disabled}>
+      {children}
+    </S.button>
+  );
+};
+
+export default Button;

--- a/src/component/common/Button/Button.style.js
+++ b/src/component/common/Button/Button.style.js
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+const S = {
+  button: styled.button`
+    background-color: ${(props) => props.theme.colors.blue};
+    color: ${(props) => props.theme.colors.white};
+    height: 3rem;
+    padding: 0.5rem 1rem;
+    border-radius: 2rem;
+  `,
+};
+
+export default S;

--- a/src/component/common/Input/Input.jsx
+++ b/src/component/common/Input/Input.jsx
@@ -1,0 +1,7 @@
+import S from './Input.style';
+
+const Input = ({ ...props }) => {
+  return <S.Input {...props} />;
+};
+
+export default Input;

--- a/src/component/common/Input/Input.jsx
+++ b/src/component/common/Input/Input.jsx
@@ -1,7 +1,8 @@
+import { forwardRef } from 'react';
 import S from './Input.style';
 
-const Input = ({ ...props }) => {
-  return <S.Input {...props} />;
-};
+const Input = forwardRef((props, ref) => {
+  return <S.Input ref={ref} {...props} />;
+});
 
 export default Input;

--- a/src/component/common/Input/Input.style.js
+++ b/src/component/common/Input/Input.style.js
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+
+const S = {
+  Input: styled.input`
+    width: 100%;
+    height: 3rem;
+    padding: 0.5rem 1.5rem;
+    border: 1px solid ${(props) => props.theme.colors.blue};
+    border-radius: 2rem;
+    font-size: 1rem;
+
+    &::placeholder {
+      color: ${(props) => props.theme.colors.grey2};
+    }
+  `,
+};
+
+export default S;

--- a/src/hook/index.js
+++ b/src/hook/index.js
@@ -1,0 +1,3 @@
+import useLogin from './useLogin';
+
+export { useLogin };

--- a/src/hook/useLogin.js
+++ b/src/hook/useLogin.js
@@ -1,0 +1,24 @@
+import { useRef } from 'react';
+const useLogin = () => {
+  const userIdRef = useRef();
+  const userPwdRef = useRef();
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const inputData = {
+      email: userIdRef.current.value,
+      password: userPwdRef.current.value,
+    };
+
+    // TODO: api 나오면 console 대신 axios 호출
+    console.log(`email: ${inputData.email} pwd: ${inputData.password}`);
+  };
+
+  return {
+    userIdRef,
+    userPwdRef,
+    handleSubmit,
+  };
+};
+
+export default useLogin;

--- a/src/pages/Login/Login.jsx
+++ b/src/pages/Login/Login.jsx
@@ -1,4 +1,45 @@
+import Button from '../../component/common/Button/Button';
+import Input from '../../component/common/Input/Input';
+import logo from '../../assets/images/logo.svg';
+import S from './style';
+import { NavLink } from 'react-router-dom';
+import { useLogin } from '../../hook';
+
 const Login = () => {
-  return <div>Login</div>;
+  const { userIdRef, userPwdRef, handleSubmit } = useLogin();
+  return (
+    <S.Wrapper>
+      <img src={logo} alt="메인로고" />
+      <S.ButtonContainer>
+        <Input
+          type="text"
+          ref={userIdRef}
+          placeholder="이메일을 입력해주세요"
+        />
+        <Input
+          type="password"
+          ref={userPwdRef}
+          autocomplete="current-password"
+          placeholder="비밀번호를 입력해주세요"
+        />
+        <Button type="submit" onClick={handleSubmit}>
+          로그인
+        </Button>
+      </S.ButtonContainer>
+      <S.LoginNav>
+        <li>
+          <NavLink to="/">아이디 찾기</NavLink>
+        </li>
+        <p>|</p>
+        <li>
+          <NavLink to="/">비밀번호 찾기</NavLink>
+        </li>
+        <p>|</p>
+        <li>
+          <NavLink to="/signup">회원가입</NavLink>
+        </li>
+      </S.LoginNav>
+    </S.Wrapper>
+  );
 };
 export default Login;

--- a/src/pages/Login/style.js
+++ b/src/pages/Login/style.js
@@ -1,0 +1,33 @@
+import styled from 'styled-components';
+
+const S = {
+  Wrapper: styled.section`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    margin: 13% 0;
+    gap: 2rem;
+  `,
+
+  ButtonContainer: styled.form`
+    display: flex;
+    flex-direction: column;
+    width: 31%;
+    gap: 0.6rem;
+  `,
+
+  LoginNav: styled.nav`
+    display: flex;
+    width: 25%;
+    justify-content: space-evenly;
+    color: ${(props) => props.theme.colors.grey3};
+
+    & p {
+      margin: 0 1rem;
+      font-weight: 900;
+    }
+  `,
+};
+
+export default S;


### PR DESCRIPTION
#  작업 내용
- [x] button 공용 컴포넌트에 만들어뒀습니다. 
- [x] Input 공용 컴포넌트에 만들어뒀습니다. 상태관리는 useRef로 하려고 합니다 
- [x] 로그인 페이지를 구현했습니다. 내부 로직은 custom hook 으로 분리하여, useLogin으로 구현했습니다. 

# ✅ PR Point
custom hook 중앙관리하고 싶어서, 내부에 index 파일 만들어서 거기에서 꺼내쓰고 싶습니다 !
그리구 버튼이랑 input 공용 컴포넌트 만들었습니다. 로그인/회원가입은 모양 거의 똑같아서 필요할때 prop으로 모양 바꾸면서 
공용으로 쓰면 좋을 것 같습니다! 

# 👀 스크린샷 / GIF / 링크
![image](https://github.com/user-attachments/assets/5e36458d-8ab7-467d-9c48-9b8c4864cca1)
