### PR TITLE
Feature/join: 회원가입 페이지 구현 

### DIFF
--- a/src/component/common/Button/Button.style.js
+++ b/src/component/common/Button/Button.style.js
@@ -2,7 +2,9 @@ import styled from 'styled-components';
 
 const S = {
   button: styled.button`
-    background-color: ${(props) => props.theme.colors.blue};
+    background-color: ${({ disabled, theme }) =>
+      disabled ? theme.colors.grey2 : theme.colors.blue};
+    cursor: ${({ disabled }) => (disabled ? 'disabled' : 'pointer')};
     color: ${(props) => props.theme.colors.white};
     height: 3rem;
     padding: 0.5rem 1rem;

--- a/src/constants/JoinForm.js
+++ b/src/constants/JoinForm.js
@@ -1,0 +1,58 @@
+const JOIN_FORM = [
+  {
+    label: '이메일',
+    info: [{ type: 'text', placeholder: '이메일을 입력하세요', name: 'email' }],
+  },
+  {
+    label: '비밀번호',
+    info: [
+      {
+        type: 'password',
+        placeholder: '비밀번호를 입력하세요',
+        name: 'password',
+      },
+    ],
+  },
+  {
+    label: '비밀번호 확인',
+    info: [
+      {
+        type: 'password',
+        placeholder: '비밀번호를 입력하세요',
+        name: 'confirmPwd',
+      },
+    ],
+  },
+  {
+    label: '이름',
+    info: [
+      {
+        type: 'text',
+        placeholder: '이름을 입력하세요',
+        name: 'name',
+      },
+    ],
+  },
+  {
+    label: '학번',
+    info: [
+      {
+        type: 'number',
+        placeholder: '학번을 입력하세요',
+        name: 'studentNum',
+      },
+    ],
+  },
+  {
+    label: '전회번호',
+    info: [
+      {
+        type: 'text',
+        placeholder: '전화번호를 입력하세요',
+        name: 'phoneNum',
+      },
+    ],
+  },
+];
+
+export default JOIN_FORM;

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,0 +1,3 @@
+import JOIN_FORM from './JoinForm';
+
+export { JOIN_FORM };

--- a/src/hook/index.js
+++ b/src/hook/index.js
@@ -1,3 +1,4 @@
 import useLogin from './useLogin';
+import useSignUp from './useSignUp';
 
-export { useLogin };
+export { useLogin, useSignUp };

--- a/src/hook/useSignUp.js
+++ b/src/hook/useSignUp.js
@@ -1,0 +1,61 @@
+import { validateField } from '../utils';
+import { useState } from 'react';
+
+const useSignUp = () => {
+  const [joinForm, setJoinForm] = useState({
+    email: '',
+    password: '',
+    confirmPwd: '',
+    name: '',
+    studentNum: '',
+    phoneNum: '',
+  });
+
+  const [errors, setErrors] = useState({
+    email: null,
+    password: null,
+    confirmPwd: null,
+    name: null,
+    studentNum: null,
+    phoneNum: null,
+  });
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setJoinForm((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  const handleBlur = (e) => {
+    const { name, value } = e.target;
+    const errorMsg = validateField(name, value, joinForm);
+    setErrors((prev) => ({
+      ...prev,
+      [name]: errorMsg,
+    }));
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    alert(JSON.stringify(joinForm));
+  };
+
+  const isFormValid =
+    Object.values(joinForm).every((value) => value.trim() !== '') &&
+    Object.values(errors).every((error) => error === null);
+
+  return {
+    joinForm,
+    setJoinForm,
+    errors,
+    setErrors,
+    handleChange,
+    handleBlur,
+    handleSubmit,
+    disabled: !isFormValid,
+  };
+};
+
+export default useSignUp;

--- a/src/pages/SignUp/SignUp.jsx
+++ b/src/pages/SignUp/SignUp.jsx
@@ -1,4 +1,41 @@
+import Input from '../../component/common/Input/Input';
+import Button from '../../component/common/Button/Button';
+import S from './style';
+import { JOIN_FORM } from '../../constants';
+import { useSignUp } from '../../hook';
+
 const SignUp = () => {
-  return <div>SignUp</div>;
+  const { joinForm, errors, handleChange, handleBlur, handleSubmit, disabled } =
+    useSignUp();
+
+  return (
+    <S.Wrapper>
+      <h1>회원가입</h1>
+      <S.ButtonContainer>
+        {JOIN_FORM.map((input, index) => {
+          const field = input.info[0];
+          const errorMessage = errors[field.name];
+
+          return (
+            <S.ButtonBox key={index}>
+              <p>{input.label}</p>
+              <Input
+                {...field}
+                value={joinForm[field.name]}
+                onChange={handleChange}
+                onBlur={handleBlur}
+                className={errorMessage ? 'err' : ''}
+              />
+              {errorMessage && <p className="err-meg">{errorMessage}</p>}
+            </S.ButtonBox>
+          );
+        })}
+        <Button type="submit" onClick={handleSubmit} disabled={disabled}>
+          회원가입
+        </Button>
+      </S.ButtonContainer>
+    </S.Wrapper>
+  );
 };
+
 export default SignUp;

--- a/src/pages/SignUp/style.js
+++ b/src/pages/SignUp/style.js
@@ -1,0 +1,49 @@
+import styled from 'styled-components';
+
+const S = {
+  Wrapper: styled.section`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    margin: 5% 0;
+    gap: 2rem;
+    color: ${({ theme }) => theme.colors.blue};
+
+    & h1 {
+      font-size: 2rem;
+      font-weight: 600;
+    }
+  `,
+
+  ButtonContainer: styled.form`
+    display: flex;
+    flex-direction: column;
+    width: 31%;
+    gap: 1rem;
+
+    & button {
+      margin-top: 1.5rem;
+    }
+  `,
+
+  ButtonBox: styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+
+    & > p {
+      margin-left: 0.8rem;
+    }
+
+    & .err {
+      border: 1.5px solid ${({ theme }) => theme.colors.error};
+    }
+    & .err-meg {
+      color: ${({ theme }) => theme.colors.error};
+      font-size: 0.7rem;
+    }
+  `,
+};
+
+export default S;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,3 @@
+import validateField from './validation';
+
+export { validateField };

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -1,0 +1,52 @@
+const validateField = (name, value, joinForm) => {
+  switch (name) {
+    case 'email':
+      if (!value.trim()) {
+        return '빈칸없이 입력해주세요';
+      }
+      const emailRegex = /^[a-zA-Z0-9._-]+@uos\.ac\.kr$/;
+      return emailRegex.test(value)
+        ? null
+        : '학교 이메일을 입력해주세요 (uos.ac.kr)';
+
+    case 'password':
+      if (!value.trim()) {
+        return '빈칸없이 입력해주세요';
+      }
+      return value.length >= 4 ? null : '비밀번호는 4글자 이상이어야 합니다';
+
+    case 'confirmPwd':
+      if (!value.trim()) {
+        return '빈칸없이 입력해주세요';
+      }
+      return value === joinForm.password
+        ? null
+        : '비밀번호가 일치하지 않습니다';
+
+    case 'name':
+      if (!value.trim()) {
+        return '빈칸없이 입력해주세요';
+      }
+      return null;
+
+    case 'studentNum':
+      if (!value.trim()) {
+        return '빈칸없이 입력해주세요';
+      }
+      return value.length === 10 ? null : '학번을 10자리로 입력해주세요';
+
+    case 'phoneNum':
+      if (!value.trim()) {
+        return '빈칸없이 입력해주세요';
+      }
+      const phoneRegex = /^[0-9]{11}$/;
+      return phoneRegex.test(value)
+        ? null
+        : '전화번호는 11자리 숫자여야 합니다';
+
+    default:
+      return null;
+  }
+};
+
+export default validateField;


### PR DESCRIPTION
#  작업 내용
- [x] 회원 가입 페이지를 만들었습니다.
- [x] 입력 폼은 상수처리를 통해, `label` / `type`/ `name` 을 정의했습니다.
- [x]  `useSignUp` 으로 로직을 분리했고, 각 입력창의 유효성 검사를 위해 `validation` 파일을 만들었습니다. 
- [x] 각 입력 창마다, 유효겁사를 했고  유효하지 못한 값이 있을 경우 버튼을 `disabled` 처리했습니다.

# ✅ PR Point
그 원래 피그마에는 placeholder 에 오류 메시지가 나오는걸로 되있었는데, 그렇게 되면 창 비었을떄만 오류 메시지가 나와서 
그냥 해당하는 input 아래에 메시지를 출력하도록 작성했습니다. 
모든 입력창에는 공백인 경우를 고려했고, 비밀번호 -> 4자리 이상 / 비밀번호 확인 -> 비밀번호와 같은지 / 전화번호 -> 11자 인지 / 학번 -> 10글자인지 / 이메일 -> @ 포함 여부 / uos.ac.kr 로 끝나는지 여부 판별했습니다

# 👀 스크린샷 / GIF / 링크
정상입력
![image](https://github.com/user-attachments/assets/13a596c8-72da-4cab-9f48-89a891b388d4)

오류처리 
![image](https://github.com/user-attachments/assets/38e95f6f-d8bb-4e61-a64e-8867a351f745)
