### PR TITLE
Feat: 헤더 하단 네비게이션바 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ import Login from './pages/Login';
 import SignUp from './pages/SignUp';
 import NotFound from './pages/NotFound';
 import Header from './component/common/Header/Header';
+import Navigation from './component/common/navigation/Navigation';
 
 const GlobalStyle = createGlobalStyle`${global}`;
 
@@ -28,6 +29,7 @@ const Layout = () => (
 const HeaderLayout = () => (
   <>
     <Header />
+    <Navigation />
     <Outlet />
   </>
 );

--- a/src/component/common/navigation/Navigation.jsx
+++ b/src/component/common/navigation/Navigation.jsx
@@ -1,0 +1,31 @@
+import S from './Navigation.style';
+import { useState } from 'react';
+import { NavLink } from 'react-router-dom';
+import { NAVIGATION_ITEMS } from '../../../constants';
+
+const Navigation = () => {
+  const [pressed, setPressed] = useState(0);
+
+  const handleLinkClick = (index) => {
+    setPressed(index);
+  };
+
+  return (
+    <S.NavWrapper>
+      <S.NavContainer>
+        {NAVIGATION_ITEMS.map(({ text, path }, index) => (
+          <NavLink
+            key={index}
+            to={`/${path}`}
+            onMouseDown={() => handleLinkClick(index)}
+            className={pressed === index ? 'pressed' : ''}
+          >
+            {text}
+          </NavLink>
+        ))}
+      </S.NavContainer>
+    </S.NavWrapper>
+  );
+};
+
+export default Navigation;

--- a/src/component/common/navigation/Navigation.style.js
+++ b/src/component/common/navigation/Navigation.style.js
@@ -1,0 +1,36 @@
+import styled from 'styled-components';
+
+const S = {
+  NavWrapper: styled.section`
+    width: 100%;
+    justify-content: space-between;
+    align-items: center;
+    align-self: stretch;
+
+    box-shadow: 0px 4px 10px ${({ theme }) => theme.colors.grey2};
+  `,
+
+  NavContainer: styled.nav`
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    margin-left: 1rem;
+    padding: 1.3rem 1rem;
+
+    gap: 2.5rem;
+    & a {
+      color: ${({ theme }) => theme.colors.grey3};
+      text-align: center;
+      font-family: Inter;
+      font-size: 1.2rem;
+      font-weight: 600;
+      line-height: normal;
+    }
+
+    & a.pressed {
+      color: ${({ theme }) => theme.colors.blue};
+    }
+  `,
+};
+
+export default S;

--- a/src/constants/Nav.js
+++ b/src/constants/Nav.js
@@ -1,0 +1,16 @@
+const NAVIGATION_ITEMS = [
+  {
+    text: '모집',
+    path: '',
+  },
+  {
+    text: '모집',
+    path: '',
+  },
+  {
+    text: '지원서 작성',
+    path: '',
+  },
+];
+
+export default NAVIGATION_ITEMS;

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,3 +1,4 @@
 import JOIN_FORM from './JoinForm';
+import NAVIGATION_ITEMS from './Nav';
 
-export { JOIN_FORM };
+export { JOIN_FORM, NAVIGATION_ITEMS };


### PR DESCRIPTION
#  작업 내용
- [x] 헤더 하단의 네비게이션을 구현했습니다. 
- [x] app.jsx 에 있는 헤더 레이아웃에 껴놨습니다  

# ✅ PR Point
근데 경로들이 좀 애매해서... 모집이 디폴트고, 
평점이면 어디로 이동하죠..? 저희 평점 리스트는 없어서 일단은 메인으로 가게 임시로 설정했습니다. 

# 👀 스크린샷 / GIF / 링크
![image](https://github.com/user-attachments/assets/b7f1c8ec-3159-4d0e-914f-dcb50cc96439)
